### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.372.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.19.2
-	github.com/alexfalkowski/go-service/v2 v2.371.0
+	github.com/alexfalkowski/go-service/v2 v2.372.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.19.2 h1:wsqGEevu5mF0+/3QNABgB7R2gpGk4j9fwuMtbzIVzuo=
 github.com/alexfalkowski/go-health/v2 v2.19.2/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.371.0 h1:D8bSIECCZxHccjCpi8J2410QhlhxSrb258ExLtQiSX8=
-github.com/alexfalkowski/go-service/v2 v2.371.0/go.mod h1:WS/aUNbKp+MTsPEh115Nw77HEQ32xUrHpzl+SNnGmuU=
+github.com/alexfalkowski/go-service/v2 v2.372.0 h1:ivvgtFXPlzzkfLBlVyP1CKXoGqnMUzewUjeZs9boQq8=
+github.com/alexfalkowski/go-service/v2 v2.372.0/go.mod h1:WS/aUNbKp+MTsPEh115Nw77HEQ32xUrHpzl+SNnGmuU=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/alexfalkowski/go-service/v2/cli"
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/status/internal/cmd"
 )
 
@@ -11,5 +12,5 @@ var app = cli.NewApplication(func(command cli.Commander) {
 })
 
 func main() {
-	app.ExitOnError(context.Background())
+	os.Exit(app.RunCode(context.Background()))
 }

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       cucumber-tag-expressions (> 6, < 9)
     cucumber-cucumber-expressions (18.1.0)
       bigdecimal
-    cucumber-gherkin (39.0.0)
+    cucumber-gherkin (39.1.0)
       cucumber-messages (>= 31, < 33)
     cucumber-html-formatter (23.1.0)
       cucumber-messages (> 23, < 33)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.372.0
