### PR TITLE
test(feature): cover status endpoint edge cases

### DIFF
--- a/test/features/health/transport/http/observability.feature
+++ b/test/features/health/transport/http/observability.feature
@@ -2,18 +2,18 @@ Feature: Observability
 
   Observability is a measure of how well internal states of a system can be inferred by knowledge of its external outputs.
 
-  Scenario: Health with HTTP
-    When the system requests the "health" with HTTP
-    Then the system should respond with a healthy status with HTTP
+  Scenario: Health
+    When the system requests the "health"
+    Then the system should respond with a healthy status
 
-  Scenario: Liveness with HTTP
-    When the system requests the "liveness" with HTTP
-    Then the system should respond with a healthy status with HTTP
+  Scenario: Liveness
+    When the system requests the "liveness"
+    Then the system should respond with a healthy status
 
-  Scenario: Readiness with HTTP
-    When the system requests the "readiness" with HTTP
-    Then the system should respond with a healthy status with HTTP
+  Scenario: Readiness
+    When the system requests the "readiness"
+    Then the system should respond with a healthy status
 
   Scenario: Metrics
-    When the system requests the "metrics" with HTTP
+    When the system requests the "metrics"
     Then the system should respond with metrics

--- a/test/features/step_definitions/health/transport/http/observability_steps.rb
+++ b/test/features/step_definitions/health/transport/http/observability_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-When('the system requests the {string} with HTTP') do |name|
+When('the system requests the {string}') do |name|
   opts = {
     headers: { request_id: SecureRandom.uuid },
     read_timeout: 10, open_timeout: 10
@@ -9,7 +9,7 @@ When('the system requests the {string} with HTTP') do |name|
   @response = Nonnative.observability.send(name, opts)
 end
 
-Then('the system should respond with a healthy status with HTTP') do
+Then('the system should respond with a healthy status') do
   expect(@response.code).to eq(200)
   expect(@response.body.strip).to eq('SERVING')
 end

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -1,47 +1,37 @@
 # frozen_string_literal: true
 
-When('I request to set the code {int} with HTTP') do |code|
-  opts = {
-    headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Status-ruby-client/1.0 HTTP/1.0',
-      content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
-
-  @response = Status::V1.http.code(code, '1ms', opts)
+When('I request to set the code {int}') do |code|
+  @response = Status::V1.http.code(code, '1ms', Status::V1.http.options)
 end
 
-When('I request to set the invalid code {string} with HTTP') do |code|
-  opts = {
-    headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Status-ruby-client/1.0 HTTP/1.0',
-      content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
-
-  @response = Status::V1.http.code(code, '1ms', opts)
+When('I request to set the code {int} without sleep') do |code|
+  @response = Status::V1.http.code(code, '', Status::V1.http.options)
 end
 
-When('I request to set the code {string} and invalid {string} for HTTP') do |code, sleep|
-  opts = {
-    headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Status-ruby-client/1.0 HTTP/1.0',
-      content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
-
-  @response = Status::V1.http.code(code, sleep, opts)
+When('I request to set the code {int} and sleep {string}') do |code, sleep|
+  start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  @response = Status::V1.http.code(code, sleep, Status::V1.http.options)
+  @elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
 end
 
-Then('I should receive a bad request response from HTTP') do
+When('I request to set the invalid code {string}') do |code|
+  @response = Status::V1.http.code(code, '1ms', Status::V1.http.options)
+end
+
+When('I request to set the code {string} and invalid {string}') do |code, sleep|
+  @response = Status::V1.http.code(code, sleep, Status::V1.http.options)
+end
+
+Then('I should receive a bad request response') do
   expect(@response.code).to eq(400)
   expect(@response.body.length).to be > 0
 end
 
-Then('I should receive a response with {int} from HTTP') do |code|
+Then('I should receive a response with {int} and {string}') do |code, body|
   expect(@response.code).to eq(code)
-  expect(@response.body.length).to be > 0
+  expect(@response.body.strip).to eq(body)
+end
+
+Then('I should receive the response in at least {int} ms') do |time|
+  expect(@elapsed * 1000).to be >= time
 end

--- a/test/features/step_definitions/v1/transport/http/benchmark_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/benchmark_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-When('I request with HTTP which performs in {int} ms') do |time|
+When('I request which performs in {int} ms') do |time|
   opts = {
     headers: {
       request_id: SecureRandom.uuid, user_agent: 'Status-ruby-client/1.0 HTTP/1.0',

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -3,18 +3,28 @@ Feature: Server
   Server allows users to get different status codes.
 
   Scenario Outline: Set valid status code
-    When I request to set the code <code> with HTTP
-    Then I should receive a response with <code> from HTTP
+    When I request to set the code <code>
+    Then I should receive a response with <code> and "<body>"
 
     Examples:
-      | code |
-      | 200  |
-      | 400  |
-      | 500  |
+      | code | body                      |
+      | 200  | 200 OK                    |
+      | 400  | 400 Bad Request           |
+      | 500  | 500 Internal Server Error |
+      | 999  | 999                       |
+
+  Scenario: Set valid status code without sleep
+    When I request to set the code 200 without sleep
+    Then I should receive a response with 200 and "200 OK"
+
+  Scenario: Set valid sleep
+    When I request to set the code 200 and sleep "50ms"
+    Then I should receive a response with 200 and "200 OK"
+    And I should receive the response in at least 50 ms
 
   Scenario Outline: Set invalid status code
-    When I request to set the invalid code "<code>" with HTTP
-    Then I should receive a bad request response from HTTP
+    When I request to set the invalid code "<code>"
+    Then I should receive a bad request response
 
     Examples:
       | code    |
@@ -25,8 +35,8 @@ Feature: Server
       | invalid |
 
   Scenario Outline: Set invalid sleep
-    When I request to set the code "200" and invalid "<sleep>" for HTTP
-    Then I should receive a bad request response from HTTP
+    When I request to set the code "200" and invalid "<sleep>"
+    Then I should receive a bad request response
 
     Examples:
       | sleep   |

--- a/test/features/v1/transport/http/benchmark.feature
+++ b/test/features/v1/transport/http/benchmark.feature
@@ -3,5 +3,5 @@ Feature: Benchmark HTTP API
   Make sure these endpoints perform at their best.
 
   Scenario: Set code in a good time frame and memory.
-    When I request with HTTP which performs in 15 ms
+    When I request which performs in 15 ms
     And the process 'server' should consume less than '70mb' of memory

--- a/test/lib/status.rb
+++ b/test/lib/status.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'securerandom'
-
 require 'status/v1/http'
 
 module Status

--- a/test/lib/status/v1/http.rb
+++ b/test/lib/status/v1/http.rb
@@ -1,10 +1,25 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+
 module Status
   module V1
     class HTTP < Nonnative::HTTPClient
-      def code(code, sleep, opts = {})
-        get("v1/status/#{code}?sleep=#{sleep}", opts)
+      def options
+        {
+          headers: {
+            request_id: SecureRandom.uuid, user_agent: 'Status-ruby-client/1.0 HTTP/1.0',
+            content_type: :json, accept: :json
+          },
+          read_timeout: 10, open_timeout: 10
+        }
+      end
+
+      def code(code, sleep = '', opts = {})
+        path = "v1/status/#{code}"
+        path = "#{path}?sleep=#{sleep}" unless sleep.to_s.empty?
+
+        get(path, opts)
       end
     end
   end


### PR DESCRIPTION
## What

- Add no-sleep, upper-bound, exact response body, and valid sleep coverage for the status endpoint.
- Move shared Ruby request options into the HTTP test client and simplify Cucumber step wording now HTTP is the only transport.

## Why

- Protect the documented status-code and optional sleep behavior from regressions.
- Keep feature scenarios focused on behavior instead of repeating transport wording.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
