### PR TITLE
feat(reliability): cap delayed status responses

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,12 @@ linters:
   settings:
     lll:
       line-length: 140
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+          toml: snake
+          yaml: snake
   exclusions:
     generated: lax
     presets:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@ Useful direct run while debugging:
 - Ruby test harness dependencies live in `test/Gemfile`.
 - `test/nonnative.yml` expects the service on `http://localhost:11000`.
 - Test and coverage artifacts are written under `test/reports/`.
-- The `/v1/status/{code}` handler also accepts `sleep=<duration>` and parses
-  it with `time.ParseDuration`.
+- The `/v1/status/{code}` handler also accepts `sleep=<duration>`, parses it
+  with `time.ParseDuration`, and rejects values above the effective `maxSleep`.
 
 ## Intentional design choices
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ GET /v1/status/{code}?sleep=50ms
 | Parameter | Location | Required | Description |
 | --------- | -------- | -------- | ----------- |
 | `code` | Path | Yes | Status code to return. Named codes include their standard reason phrase, such as `200 OK`. |
-| `sleep` | Query | No | Delay before returning the response. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), for example `50ms`, `1s`, or `2m`. |
+| `sleep` | Query | No | Delay before returning the response. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), for example `50ms`, `1s`, or `2m`. Must be less than or equal to the effective `max_sleep`. |
 
 > [!CAUTION]
 > `sleep` intentionally delays the response. Keep durations short in tests so client timeouts and CI jobs do not wait longer than expected.
@@ -90,6 +90,14 @@ For codes without a standard reason phrase, the body contains the numeric code:
 ```
 
 Invalid status codes or invalid `sleep` values return `400 Bad Request`.
+
+The maximum accepted sleep duration defaults to `5m`. Configure a lower maximum with:
+
+```yaml
+max_sleep: 2m
+```
+
+When set, `max_sleep` must be greater than `0` and less than or equal to `5m`.
 
 ## 💓 Health
 

--- a/internal/api/v1/transport/http/http.go
+++ b/internal/api/v1/transport/http/http.go
@@ -11,27 +11,38 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/status/internal/config"
 )
 
 // ErrInvalidStatusCode is returned when the requested status code is unsupported.
 var ErrInvalidStatusCode = errors.New("status: invalid status code")
 
+// ErrInvalidSleepDuration is returned when the requested sleep duration is unsupported.
+var ErrInvalidSleepDuration = errors.New("status: invalid sleep duration")
+
 // Response for route.
 type Response any
 
 // Register for http.
-func Register() {
+func Register(cfg *config.Config) {
 	rest.Get("/v1/status/{code}", func(ctx context.Context) (*Response, error) {
 		req := meta.Request(ctx)
-		query := req.URL.Query()
 
-		if s := query.Get("sleep"); !strings.IsEmpty(s) {
-			t, err := time.ParseDuration(s)
+		code, err := parseStatusCode(req.PathValue("code"))
+		if err != nil {
+			return nil, status.SafeError(http.StatusBadRequest, err)
+		}
+
+		if s := req.URL.Query().Get("sleep"); !strings.IsEmpty(s) {
+			sleep, err := time.ParseDuration(s)
 			if err != nil {
 				return nil, status.SafeError(http.StatusBadRequest, err)
 			}
+			if sleep > cfg.GetMaxSleep() {
+				return nil, status.SafeError(http.StatusBadRequest, ErrInvalidSleepDuration)
+			}
 
-			timer := time.NewTimer(t)
+			timer := time.NewTimer(sleep)
 			defer timer.Stop()
 
 			select {
@@ -39,11 +50,6 @@ func Register() {
 				return nil, status.SafeError(http.StatusRequestTimeout, ctx.Err())
 			case <-timer.C:
 			}
-		}
-
-		code, err := parseStatusCode(req.PathValue("code"))
-		if err != nil {
-			return nil, status.SafeError(http.StatusBadRequest, err)
 		}
 
 		return nil, status.Errorf(code, "%d %s", code, http.StatusText(code))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,13 +2,29 @@ package config
 
 import (
 	"github.com/alexfalkowski/go-service/v2/config"
+	"github.com/alexfalkowski/go-service/v2/runtime"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/status/internal/health"
+	"github.com/go-playground/validator/v10"
 )
+
+// MaxSleepLimit is the largest configured status response delay.
+const MaxSleepLimit = 5 * time.Minute
 
 // Config for the service.
 type Config struct {
 	Health         *health.Config `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty" validate:"required"`
 	*config.Config `yaml:",inline" json:",inline" toml:",inline" validate:"required"`
+	MaxSleep       time.Duration `yaml:"max_sleep,omitempty" json:"max_sleep,omitempty" toml:"max_sleep,omitempty" validate:"max_sleep"`
+}
+
+// GetMaxSleep returns the configured max sleep, falling back to MaxSleepLimit.
+func (c *Config) GetMaxSleep() time.Duration {
+	if c == nil || c.MaxSleep == 0 {
+		return MaxSleepLimit
+	}
+
+	return c.MaxSleep
 }
 
 func decorateConfig(cfg *Config) *config.Config {
@@ -17,4 +33,14 @@ func decorateConfig(cfg *Config) *config.Config {
 
 func healthConfig(cfg *Config) *health.Config {
 	return cfg.Health
+}
+
+func decorateValidator(v *config.Validator) *config.Validator {
+	runtime.Must(v.RegisterValidation("max_sleep", validateMaxSleep))
+	return v
+}
+
+func validateMaxSleep(fl validator.FieldLevel) bool {
+	maxSleep := time.Duration(fl.Field().Int())
+	return maxSleep == 0 || (maxSleep > 0 && maxSleep <= MaxSleepLimit)
 }

--- a/internal/config/module.go
+++ b/internal/config/module.go
@@ -7,6 +7,7 @@ import (
 
 // Module for fx.
 var Module = di.Module(
+	di.Decorate(decorateValidator),
 	di.Constructor(config.NewConfig[Config]),
 	di.Decorate(decorateConfig),
 	di.Constructor(healthConfig),

--- a/test/.config/server.yml
+++ b/test/.config/server.yml
@@ -4,15 +4,13 @@ health:
   timeout: 1s
 id:
   kind: uuid
+max_sleep: 2m
 telemetry:
   logger:
     kind: text
     level: info
   metrics:
     kind: prometheus
-  tracer:
-    kind: otlp
-    url: http://localhost:4318/v1/traces
 transport:
   http:
     address: tcp://:11000

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -35,3 +35,7 @@ end
 Then('I should receive the response in at least {int} ms') do |time|
   expect(@elapsed * 1000).to be >= time
 end
+
+Then('I should receive the response in less than {int} ms') do |time|
+  expect(@elapsed * 1000).to be < time
+end

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -22,6 +22,11 @@ Feature: Server
     Then I should receive a response with 200 and "200 OK"
     And I should receive the response in at least 50 ms
 
+  Scenario: Reject sleep above maximum
+    When I request to set the code 200 and sleep "5m1s"
+    Then I should receive a bad request response
+    And I should receive the response in less than 1000 ms
+
   Scenario Outline: Set invalid status code
     When I request to set the invalid code "<code>"
     Then I should receive a bad request response


### PR DESCRIPTION
## What
- Add a configurable maximum delay for `/v1/status/{code}?sleep=...`, defaulting to 5m and rejecting over-limit values before allocating the timer.
- Parse and validate status codes before sleeping so invalid paths return quickly.
- Remove the local OTLP tracer config from the test server config so feature and benchmark runs no longer expect a collector they do not start.
- Document `maxSleep` and update Cucumber coverage for over-limit sleeps.

## Why
- Long or accidental sleep requests could hold handler and connection state beyond the service’s intended local-test envelope.
- The local harness previously logged trace exporter connection failures because no collector is provisioned, which made expected runs noisy.

## Testing
- `make lint`
- `make specs`
- `make features`
- `make benchmarks`
- `make coverage`
- `make sec`
- `make analyse`
- `make build`
