### PR TITLE
docs(readme): clarify local service setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ From the repo root, prefer the exposed `make` targets:
 Useful direct run while debugging:
 
 ```sh
-./status server -i file:test/.config/server.yml
+./status server -config file:test/.config/server.yml
 ```
 
 ## Runtime and test notes
@@ -58,9 +58,12 @@ Useful direct run while debugging:
 - Go version is `1.26.0` in `go.mod`.
 - Ruby test harness dependencies live in `test/Gemfile`.
 - `test/nonnative.yml` expects the service on `http://localhost:11000`.
+- `test/.config/server.yml` listens on `tcp://:11000`, which binds port `11000`
+  on all interfaces; use `http://localhost:11000` for local client requests.
 - Test and coverage artifacts are written under `test/reports/`.
 - The `/v1/status/{code}` handler also accepts `sleep=<duration>`, parses it
   with `time.ParseDuration`, and rejects values above the effective `maxSleep`.
+  Longer sleeps can still exceed the configured HTTP request timeout.
 
 ## Intentional design choices
 
@@ -90,6 +93,8 @@ The main `build-service` job runs:
 - The root `Makefile` depends on the `bin` submodule and includes:
   `bin/build/make/help.mak`, `bin/build/make/http.mak`, and
   `bin/build/make/git.mak`.
+- The configured `bin` submodule URL uses GitHub SSH; fresh checkouts need
+  GitHub SSH access or a local HTTPS submodule URL override.
 - Shared git helper targets are exposed here too; some are destructive
   (`make reset`, `make purge`, branch deletion helpers, force-push helpers).
   Do not use them unless the user explicitly asks.

--- a/README.md
+++ b/README.md
@@ -30,15 +30,18 @@ git submodule update --init
 make dep
 ```
 
+The configured `bin` submodule URL uses GitHub SSH. Configure GitHub SSH access
+first, or override the submodule URL to HTTPS before initializing it.
+
 Build and run the service with the local test configuration:
 
 ```sh
 make build
-./status server -i file:test/.config/server.yml
+./status server -config file:test/.config/server.yml
 ```
 
-The local configuration binds the HTTP server to `localhost:11000`, so you can
-try it with:
+The local configuration listens on `tcp://:11000`, which binds port `11000` on
+all interfaces. For local requests, use:
 
 ```sh
 curl -i http://localhost:11000/v1/status/200
@@ -70,10 +73,10 @@ GET /v1/status/{code}?sleep=50ms
 | Parameter | Location | Required | Description |
 | --------- | -------- | -------- | ----------- |
 | `code` | Path | Yes | Status code to return. Named codes include their standard reason phrase, such as `200 OK`. |
-| `sleep` | Query | No | Delay before returning the response. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), for example `50ms`, `1s`, or `2m`. Must be less than or equal to the effective `max_sleep`. |
+| `sleep` | Query | No | Delay before returning the response. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), for example `50ms`, `1s`, or `2m`. Must be less than or equal to the effective `max_sleep` and short enough for the configured HTTP request timeout. |
 
 > [!CAUTION]
-> `sleep` intentionally delays the response. Keep durations short in tests so client timeouts and CI jobs do not wait longer than expected.
+> `sleep` intentionally delays the response. Keep durations short in tests so client timeouts and CI jobs do not wait longer than expected. The checked-in local configuration sets the HTTP timeout to `5s`.
 
 #### 📤 Response
 
@@ -97,7 +100,8 @@ The maximum accepted sleep duration defaults to `5m`. Configure a lower maximum 
 max_sleep: 2m
 ```
 
-When set, `max_sleep` must be greater than `0` and less than or equal to `5m`.
+Omitting `max_sleep` or setting it to `0` uses the `5m` default. Positive
+configured values must be less than or equal to `5m`.
 
 ## 💓 Health
 
@@ -151,7 +155,8 @@ Install these before running the full local workflow:
 
 - Go `1.26.0`, as declared in `go.mod`.
 - Ruby and Bundler for the `test/` harness.
-- The `bin` submodule, initialized with `git submodule update --init`.
+- The `bin` submodule, initialized with `git submodule update --init`. The
+  configured submodule URL uses GitHub SSH unless you override it locally.
 
 ### 🧰 Commands
 


### PR DESCRIPTION
## What

- Correct the documented server startup flag from `-i` to `-config`.
- Document the GitHub SSH requirement for the configured `bin` submodule URL.
- Clarify that the local config listens on `tcp://:11000` while local clients can use `http://localhost:11000`.
- Document how `sleep` interacts with the configured HTTP timeout and that `max_sleep: 0` falls back to the `5m` default.

## Why

- The Quick Start command should work when copied, and setup notes should explain prerequisites that can block a fresh checkout.
- The local config wording now matches the checked-in service configuration and avoids implying a loopback-only bind.
- The status endpoint documentation now reflects the effective limits users hit when combining `sleep`, `max_sleep`, and the HTTP timeout.

## Testing

- `make help` - passed
- `make build` - passed
- `go run . server --help` - produced the expected `-c` and `-config` flags; the command exits non-zero because the app reports `flag: help requested`
- `./status server -config file:test/.config/server.yml` - passed outside the sandbox and logged `addr=[::]:11000`
