### PR TITLE
docs(readme): clarify delayed timeout behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ For codes without a standard reason phrase, the body contains the numeric code:
 
 Invalid status codes, unparsable `sleep` values, and sleeps above the effective
 `max_sleep` return `400 Bad Request`. A `sleep` accepted by `max_sleep` can
-still exceed the configured HTTP request or client timeout; in that case the
-request may time out or close before the requested status response is returned.
+still exceed the configured HTTP request timeout. When the request context is
+canceled while waiting for an accepted sleep, the service returns
+`408 Request Timeout`. A shorter client-side timeout can still close the request
+before a response is observed.
 
 The maximum accepted sleep duration defaults to `5m`. Configure a lower maximum with:
 


### PR DESCRIPTION
## What

- Clarifies that accepted `sleep` delays can still hit the configured HTTP request timeout.
- Documents the `408 Request Timeout` response for sleeps canceled by the request context, while keeping shorter client-side timeouts distinct.

## Why

- Gives callers and operators a concrete expected result for delayed status requests.
- Removes ambiguity between `max_sleep` validation, server request timeout behavior, and client-side timeout behavior.

## Testing

- `make help` - passed
- `git diff --check` - passed
- No service tests were run because this is a documentation-only change to existing behavior.

AI-assisted-by: [Codex](https://openai.com/codex/)
