### PR TITLE
docs(readme): clarify service usage contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ all interfaces. For local requests, use:
 ```sh
 curl -i http://localhost:11000/v1/status/200
 curl -i "http://localhost:11000/v1/status/503?sleep=50ms"
-curl -i http://localhost:11000/status/healthz
+curl -i http://localhost:11000/status/livez
 ```
 
 > [!IMPORTANT]
@@ -74,7 +74,7 @@ GET /v1/status/{code}?sleep=50ms
 | Parameter | Location | Required | Description |
 | --------- | -------- | -------- | ----------- |
 | `code` | Path | Yes | Status code to return. Named codes include their standard reason phrase, such as `200 OK`. |
-| `sleep` | Query | No | Delay before returning the response. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), for example `50ms`, `1s`, or `2m`. Must be less than or equal to the effective `max_sleep` and short enough for the configured HTTP request timeout. |
+| `sleep` | Query | No | Delay before returning the response. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), for example `50ms`, `1s`, or `2m`. Must be less than or equal to the effective `max_sleep` and short enough for the configured HTTP request timeout. Parsed durations at or below `0` are accepted and return without waiting. |
 
 > [!CAUTION]
 > `sleep` intentionally delays the response. Keep durations short in tests so client timeouts and CI jobs do not wait longer than expected. The checked-in local configuration sets `max_sleep` to `2m` and the HTTP timeout to `5s`, so some accepted sleeps can still outlast the transport timeout.
@@ -115,8 +115,10 @@ configured values must be less than or equal to `5m`.
 
 ## 💓 Health
 
-The shared health module exposes service-prefixed health, liveness, readiness,
-and metrics endpoints over HTTP. With the local `status` service name, use:
+The shared health module exposes service-prefixed health, liveness, and
+readiness endpoints over HTTP. The shared telemetry configuration exposes
+service-prefixed Prometheus metrics when `telemetry.metrics.kind` is
+`prometheus`. With the local `status` service name, use:
 
 | Endpoint | Check | Healthy response |
 | -------- | ----- | ---------------- |
@@ -136,13 +138,18 @@ health:
   timeout: 1s
 ```
 
+The `health` block is required. Both durations must be positive values.
+
 The repository's local configuration is in `test/.config/server.yml`.
 
 ## 🚢 Deployment
 
-The service builds as a single binary and can also be built into a Docker image
-through the shared make targets. In production-like environments, run it behind
-your normal container orchestration and health-check configuration.
+The service builds as a single binary and CI publishes the multi-architecture
+Docker image as `alexfalkowski/status`. The shared Docker make targets build
+platform-specific images for `amd64` and `arm64`; production push and manifest
+targets no-op unless the release version file is present. In production-like
+environments, run the image behind your normal container orchestration and
+health-check configuration.
 
 ## 🛠️ Development
 
@@ -158,6 +165,9 @@ The project follows the common Go service layout:
 | `internal/api/v1/transport/http/` | HTTP route registration for `/v1/status/{code}`. |
 | `internal/health/` | Health registration and HTTP observers. |
 | `test/` | Ruby nonnative/cucumber integration tests and benchmark harness. |
+
+See `test/README.md` for the Cucumber/Nonnative harness contract, benchmark
+thresholds, direct-run caveats, and generated report locations.
 
 ### 📦 Dependencies
 

--- a/internal/api/v1/module.go
+++ b/internal/api/v1/module.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexfalkowski/status/internal/api/v1/transport/http"
 )
 
-// Module for fx.
+// Module registers the v1 HTTP API routes.
 var Module = di.Module(
 	di.Register(http.Register),
 )

--- a/internal/api/v1/transport/http/http.go
+++ b/internal/api/v1/transport/http/http.go
@@ -20,10 +20,15 @@ var ErrInvalidStatusCode = errors.New("status: invalid status code")
 // ErrInvalidSleepDuration is returned when the requested sleep duration is unsupported.
 var ErrInvalidSleepDuration = errors.New("status: invalid sleep duration")
 
-// Response for route.
+// Response marks the status route response type for the shared REST transport.
 type Response any
 
-// Register for http.
+// Register adds GET /v1/status/{code} to the shared REST router.
+//
+// The route accepts status codes from 200 through 999. The optional sleep query
+// parameter is parsed as a duration, rejected when it exceeds the configured
+// maximum, and returns 408 Request Timeout when the request context is canceled
+// while waiting.
 func Register(cfg *config.Config) {
 	rest.Get("/v1/status/{code}", func(ctx context.Context) (*Response, error) {
 		req := meta.Request(ctx)

--- a/internal/cmd/module.go
+++ b/internal/cmd/module.go
@@ -8,7 +8,7 @@ import (
 	"github.com/alexfalkowski/status/internal/health"
 )
 
-// Module for fx.
+// Module composes the server command with service config, health, and v1 API wiring.
 var Module = di.Module(
 	module.Server,
 	config.Module,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,11 @@ import (
 // MaxSleepLimit is the largest configured status response delay.
 const MaxSleepLimit = 5 * time.Minute
 
-// Config for the service.
+// Config is the service configuration loaded by the server command.
+//
+// Health and the embedded shared service config are required. MaxSleep is
+// optional; zero falls back to MaxSleepLimit, and positive values must not
+// exceed MaxSleepLimit.
 type Config struct {
 	Health         *health.Config `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty" validate:"required"`
 	*config.Config `yaml:",inline" json:",inline" toml:",inline" validate:"required"`

--- a/internal/config/module.go
+++ b/internal/config/module.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 )
 
-// Module for fx.
+// Module registers service config loading, validation, and shared config projection.
 var Module = di.Module(
 	di.Decorate(decorateValidator),
 	di.Constructor(config.NewConfig[Config]),

--- a/internal/health/config.go
+++ b/internal/health/config.go
@@ -4,7 +4,8 @@ import "github.com/alexfalkowski/go-service/v2/time"
 
 // Config configures the health subsystem.
 //
-// Both fields are parsed as durations (for example: "250ms", "5s", "1m").
+// Both fields are required, must be positive, and are parsed as durations (for
+// example: "250ms", "5s", "1m").
 //
 // The values are used by the health module when registering checks and
 // observers:

--- a/internal/health/module.go
+++ b/internal/health/module.go
@@ -2,7 +2,7 @@ package health
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module registers health checks and HTTP observers for health, liveness, and readiness.
 var Module = di.Module(
 	di.Register(register),
 	di.Register(httpHealthObserver),

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,73 @@
+# 🧪 Test Harness
+
+The `test/` directory owns the Ruby Cucumber/Nonnative integration and
+benchmark harness for the `status` service. Prefer the root `make` targets for
+normal local and CI use because they build the correct Go binary before running
+the Ruby harness.
+
+## ▶️ Commands
+
+From the repository root:
+
+```sh
+make dep
+make features
+make benchmarks
+```
+
+`make dep` installs the Ruby gems under `test/vendor/bundle`. `make features`
+builds the feature test binary and runs non-benchmark Cucumber scenarios.
+`make benchmarks` builds the release binary and runs scenarios tagged
+`@benchmark`.
+
+Direct harness runs are supported only after the matching root build has
+created `./status`:
+
+```sh
+make build-test
+make -C test features
+
+make build
+make -C test benchmarks
+```
+
+## ⚙️ Runtime Contract
+
+Nonnative starts the service from `test/nonnative.yml` with:
+
+```sh
+../status server -config file:.config/server.yml
+```
+
+Run direct harness commands through `make -C test` from the repository root, or
+change into `test/` and run the same target there. The Nonnative config uses
+paths relative to `test/`. The service listens on `http://localhost:11000`, and
+port `11000` must be free before the harness starts.
+
+The local server config is `test/.config/server.yml`. It enables Prometheus
+metrics, sets `max_sleep: 2m`, and configures the HTTP transport timeout to
+`5s`.
+
+## 📈 Benchmarks
+
+The benchmark feature checks one `GET /v1/status/200?sleep=1ms` request against
+the current local thresholds:
+
+- response under `15ms`;
+- server process memory below `70mb`.
+
+Treat local benchmark failures as a prompt to inspect load, machine resources,
+and generated artifacts before assuming a service regression.
+
+## 🧾 Reports
+
+Cucumber and Nonnative write artifacts under `test/reports/`:
+
+- `index.html`: HTML Cucumber report.
+- `nonnative.log`: Nonnative process orchestration log.
+- `server.log`: service process log.
+- `*.xml`: JUnit-style Cucumber reports.
+- `*.cov`: Go coverage output from feature builds.
+
+The root `make coverage` target consumes coverage files from this directory and
+writes `test/reports/coverage.html`.


### PR DESCRIPTION
## What

- Clarify the README first-use service checks, health and metrics ownership, sleep validation, required health configuration, and Docker image publication notes.
- Add test harness documentation for Cucumber/Nonnative commands, runtime paths, benchmark thresholds, port ownership, and generated reports.
- Replace placeholder Go comments with route, config, and module ownership contracts for maintainers.

## Why

- Reduces setup and operations ambiguity for users exercising the service locally, especially in offline environments and when running the Ruby harness directly.
- Makes configuration validation and maintenance boundaries visible without requiring readers to inspect handler, DI, or shared tooling internals.

## Testing

- `make help` - passed
- `make lint` - passed
