### PR TITLE
test(feature): centralize harness request options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor
 dist
 .source-key
 ISSUES.md
+FEATURES.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,17 @@ Useful direct run while debugging:
   registration, which checks external internet connectivity by default. This is
   expected for this service; do not flag the external egress dependency as an
   issue unless the task is specifically about changing health semantics.
+- This repository consumes shared Make targets from the `bin/` submodule. If a
+  one-command local CI preflight target is needed, it should be added to the
+  shared `bin` Make fragments rather than as a service-local target here. Do not
+  flag the lack of a root `verify` or `ci-checks` target as a feature gap by
+  default.
+- The Ruby code under `test/` is a local feature-test harness, not production
+  service code. Fixed localhost endpoints in `test/lib/**`, `test/nonnative.yml`,
+  and related feature helpers are intentional local harness assumptions unless
+  there is concrete evidence of current workflow breakage. Do not flag the lack
+  of environment-configurable HTTP or observability endpoints as a feature gap
+  by default.
 
 ## CI signal
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/ruby.mak

--- a/test/features/step_definitions/health/transport/http/observability_steps.rb
+++ b/test/features/step_definitions/health/transport/http/observability_steps.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 When('the system requests the {string}') do |name|
-  opts = {
-    headers: { request_id: SecureRandom.uuid },
-    read_timeout: 10, open_timeout: 10
-  }
-
-  @response = Nonnative.observability.send(name, opts)
+  @response = Nonnative.observability.send(name, Status.http_options)
 end
 
 Then('the system should respond with a healthy status') do

--- a/test/features/step_definitions/v1/transport/http/benchmark_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/benchmark_steps.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 When('I request which performs in {int} ms') do |time|
-  opts = {
+  opts = Status.http_options(
     headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Status-ruby-client/1.0 HTTP/1.0',
+      user_agent: 'Status-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   expect { Status::V1.http.code(200, '1ms', opts) }.to perform_under(time).ms
 end

--- a/test/lib/status.rb
+++ b/test/lib/status.rb
@@ -1,8 +1,30 @@
 # frozen_string_literal: true
 
+require 'securerandom'
 require 'status/v1/http'
 
 module Status
+  class << self
+    ##
+    # Returns bounded per-call options for HTTP feature-harness requests.
+    #
+    # Each call includes a generated `request_id` header. Caller-provided
+    # headers are merged afterward, so scenarios can override that value or add
+    # transport-specific headers such as content type and user agent.
+    #
+    # @param headers [Hash] HTTP headers merged after the generated request id
+    # @param read_timeout [Integer] read timeout in seconds
+    # @param open_timeout [Integer] connection open timeout in seconds
+    # @return [Hash] options compatible with `Nonnative::HTTPClient` calls
+    def http_options(headers: {}, read_timeout: 10, open_timeout: 10)
+      {
+        headers: { request_id: SecureRandom.uuid }.merge(headers),
+        read_timeout:,
+        open_timeout:
+      }
+    end
+  end
+
   module V1
     class << self
       def http

--- a/test/lib/status/v1/http.rb
+++ b/test/lib/status/v1/http.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
-require 'securerandom'
-
 module Status
   module V1
     class HTTP < Nonnative::HTTPClient
       def options
-        {
+        Status.http_options(
           headers: {
-            request_id: SecureRandom.uuid, user_agent: 'Status-ruby-client/1.0 HTTP/1.0',
+            user_agent: 'Status-ruby-client/1.0 HTTP/1.0',
             content_type: :json, accept: :json
-          },
-          read_timeout: 10, open_timeout: 10
-        }
+          }
+        )
       end
 
       def code(code, sleep = '', opts = {})


### PR DESCRIPTION
## What

- Add repository guidance for shared-bin CI preflight ownership and local Ruby feature-harness endpoint assumptions.
- Expose help output from the Ruby harness Makefile and ignore the temporary feature-gap ledger file.
- Centralize HTTP feature-harness request options behind `Status.http_options` and use it from observability, API, and benchmark HTTP requests.

## Why

- Keeps future gap and review passes focused on service work instead of accepted local harness boundaries.
- Makes the Ruby harness command surface discoverable from `test/` in the same way as other shared Make targets.
- Reduces repeated request setup while preserving generated request IDs, timeouts, and caller-specific headers.

## Testing

- `make -C test help` - passed
- `make -C test lint` - passed
- `make -C test features` - passed, covering 17 scenarios and 36 steps
- `make -C test benchmarks` - passed, covering 1 scenario and 2 steps
- `git diff --check` - passed
- `make lint` - failed before changed-code linting because `go.mod` requires `github.com/alexfalkowski/go-service/v2 v2.595.0` while `vendor/modules.txt` still marks `v2.594.0`
- `make features` - failed at the same pre-existing vendoring check before building the feature binary
