### PR TITLE
build(ci): align cache keys and reviewer guidance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,23 +14,23 @@ jobs:
       - restore_cache:
           name: restore go cache
           keys:
-            - status-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - status-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - status-go-cache-
       - restore_cache:
           name: restore ruby cache
           keys:
-            - status-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
+            - status-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}
             - status-ruby-cache-
       - run: make clean
       - run: make dep
       - save_cache:
           name: save go cache
-          key: status-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+          key: status-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
           paths:
             - ~/go/pkg/mod
       - save_cache:
           name: save ruby cache
-          key: status-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
+          key: status-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}
           paths:
             - test/vendor
       - restore_cache:
@@ -90,7 +90,7 @@ jobs:
       - restore_cache:
           name: restore go cache
           keys:
-            - status-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - status-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - status-go-cache-
       - restore_cache:
           name: restore go build cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .source-key
 ISSUES.md
 FEATURES.md
+PROJECTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,12 +78,26 @@ Useful direct run while debugging:
   shared `bin` Make fragments rather than as a service-local target here. Do not
   flag the lack of a root `verify` or `ci-checks` target as a feature gap by
   default.
+- CircleCI's `version` job runs the external `package` command from the
+  `alexfalkowski/release` image. That release tooling owns GoReleaser config
+  validation before publishing. Do not flag the absence of a separate
+  repository-local GoReleaser config validation job as a project gap by default
+  unless there is concrete evidence that the release image no longer validates
+  `.goreleaser.yml`, or this repository has explicitly decided to own a
+  pre-release GoReleaser check locally.
 - The Ruby code under `test/` is a local feature-test harness, not production
   service code. Fixed localhost endpoints in `test/lib/**`, `test/nonnative.yml`,
   and related feature helpers are intentional local harness assumptions unless
   there is concrete evidence of current workflow breakage. Do not flag the lack
   of environment-configurable HTTP or observability endpoints as a feature gap
   by default.
+- Ruby runtime selection for the `test/` harness is owned by the external
+  service CI image and shared Ruby Make wiring, not by production service code.
+  Do not flag the absence of a repository-local `.ruby-version`,
+  `.tool-versions`, `mise.toml`, or Gemfile `ruby` directive as a project gap by
+  default unless there is concrete evidence that CI no longer supplies the
+  expected runtime, or this repository has explicitly decided to own Ruby version
+  selection locally for the test harness.
 
 ## CI signal
 


### PR DESCRIPTION
## What

- Remove the generated `.source-key` checksum from the Go and Ruby dependency cache keys in CircleCI while keeping it on Go build and lint caches.
- Ignore `PROJECTS.md` alongside the other local gap-audit scratch files.
- Document that GoReleaser config validation and Ruby runtime selection are owned by the shared release and service workflow images, not service-local checks.
- Leave out the upstream `api/Makefile` hunk because this repository has no equivalent `api/Makefile`; `test/Makefile` already includes `help.mak`.

## Why

- Dependency caches should be keyed by dependency inputs instead of unrelated source changes, while source-sensitive build and lint caches still need `.source-key` invalidation.
- The reviewer guidance prevents recurring false-positive project-gap findings for responsibilities this repository intentionally delegates to shared tooling.
- Ignoring `PROJECTS.md` keeps local project-gap audit notes out of commits, consistent with `ISSUES.md` and `FEATURES.md`.

## Testing

- `ruby -e "require %q[yaml]; YAML.load_file(%q[.circleci/config.yml])"` - passed
- `git diff --check HEAD~1 -- .circleci/config.yml .gitignore AGENTS.md` - passed
- `circleci config validate .circleci/config.yml` - passed
- `make lint` - failed because `vendor/modules.txt` is out of sync with `go.mod` for `github.com/alexfalkowski/go-service/v2` (`v2.594.0` in vendor metadata versus `v2.595.0` in `go.mod`).
