### PR TITLE
feat(location): support redirect targets on status responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ all interfaces. For local requests, use:
 ```sh
 curl -i http://localhost:11000/v1/status/200
 curl -i "http://localhost:11000/v1/status/503?sleep=50ms"
+curl -i "http://localhost:11000/v1/status/302?location=/redirected"
 curl -i http://localhost:11000/status/livez
 ```
 
@@ -66,6 +67,7 @@ Returns the requested HTTP status code.
 ```http
 GET /v1/status/{code}
 GET /v1/status/{code}?sleep=50ms
+GET /v1/status/{code}?location=/redirected
 ```
 
 > [!NOTE]
@@ -75,6 +77,7 @@ GET /v1/status/{code}?sleep=50ms
 | --------- | -------- | -------- | ----------- |
 | `code` | Path | Yes | Status code to return. Named codes include their standard reason phrase, such as `200 OK`. |
 | `sleep` | Query | No | Delay before returning the response. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), for example `50ms`, `1s`, or `2m`. Must be less than or equal to the effective `max_sleep` and short enough for the configured HTTP request timeout. Parsed durations at or below `0` are accepted and return without waiting. |
+| `location` | Query | No | Redirect target to return in the `Location` header. Only valid for `300` through `399` responses. URL-encode values that contain query delimiters or other reserved characters. |
 
 > [!CAUTION]
 > `sleep` intentionally delays the response. Keep durations short in tests so client timeouts and CI jobs do not wait longer than expected. The checked-in local configuration sets `max_sleep` to `2m` and the HTTP timeout to `5s`, so some accepted sleeps can still outlast the transport timeout.
@@ -97,12 +100,13 @@ For codes without a standard reason phrase, the body contains the numeric code:
 999
 ```
 
-Invalid status codes, unparsable `sleep` values, and sleeps above the effective
-`max_sleep` return `400 Bad Request`. A `sleep` accepted by `max_sleep` can
-still exceed the configured HTTP request timeout. When the request context is
-canceled while waiting for an accepted sleep, the service returns
-`408 Request Timeout`. A shorter client-side timeout can still close the request
-before a response is observed.
+Invalid status codes, unparsable `sleep` values, sleeps above the effective
+`max_sleep`, invalid `location` values, and `location` values on non-redirect
+responses return `400 Bad Request`. A `sleep` accepted by `max_sleep` can still
+exceed the configured HTTP request timeout. When the request context is canceled
+while waiting for an accepted sleep, the service returns `408 Request Timeout`.
+A shorter client-side timeout can still close the request before a response is
+observed.
 
 The maximum accepted sleep duration defaults to `5m`. Configure a lower maximum with:
 

--- a/internal/api/v1/transport/http/http.go
+++ b/internal/api/v1/transport/http/http.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"net/url"
 	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -20,6 +21,9 @@ var ErrInvalidStatusCode = errors.New("status: invalid status code")
 // ErrInvalidSleepDuration is returned when the requested sleep duration is unsupported.
 var ErrInvalidSleepDuration = errors.New("status: invalid sleep duration")
 
+// ErrInvalidLocation is returned when the requested redirect location is unsupported.
+var ErrInvalidLocation = errors.New("status: invalid location")
+
 // Response marks the status route response type for the shared REST transport.
 type Response any
 
@@ -28,10 +32,12 @@ type Response any
 // The route accepts status codes from 200 through 999. The optional sleep query
 // parameter is parsed as a duration, rejected when it exceeds the configured
 // maximum, and returns 408 Request Timeout when the request context is canceled
-// while waiting.
+// while waiting. The optional location query parameter sets a Location response
+// header for 3xx status codes.
 func Register(cfg *config.Config) {
 	rest.Get("/v1/status/{code}", func(ctx context.Context) (*Response, error) {
 		req := meta.Request(ctx)
+		res := meta.Response(ctx)
 
 		code, err := parseStatusCode(req.PathValue("code"))
 		if err != nil {
@@ -57,6 +63,14 @@ func Register(cfg *config.Config) {
 			}
 		}
 
+		if location := req.URL.Query().Get("location"); !strings.IsEmpty(location) {
+			if !isRedirectStatusCode(code) || !isValidLocation(location) {
+				return nil, status.SafeError(http.StatusBadRequest, ErrInvalidLocation)
+			}
+
+			res.Header().Set("Location", location)
+		}
+
 		return nil, status.Errorf(code, "%d %s", code, http.StatusText(code))
 	})
 }
@@ -72,4 +86,17 @@ func parseStatusCode(code string) (int, error) {
 	}
 
 	return codeValue, nil
+}
+
+func isRedirectStatusCode(code int) bool {
+	return code >= http.StatusMultipleChoices && code < http.StatusBadRequest
+}
+
+func isValidLocation(location string) bool {
+	if strings.Contains(location, "\r") || strings.Contains(location, "\n") {
+		return false
+	}
+
+	_, err := url.Parse(location)
+	return err == nil
 }

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -14,6 +14,10 @@ When('I request to set the code {int} and sleep {string}') do |code, sleep|
   @elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
 end
 
+When('I request to set the code {int} and location {string}') do |code, location|
+  @response = Status::V1.http.code_with_location(code, location, Status::V1.http.options)
+end
+
 When('I request to set the invalid code {string}') do |code|
   @response = Status::V1.http.code(code, '1ms', Status::V1.http.options)
 end
@@ -30,6 +34,10 @@ end
 Then('I should receive a response with {int} and {string}') do |code, body|
   expect(@response.code).to eq(code)
   expect(@response.body.strip).to eq(body)
+end
+
+Then('I should receive a location {string}') do |location|
+  expect(@response.headers[:location]).to eq(location)
 end
 
 Then('I should receive the response in at least {int} ms') do |time|

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -22,10 +22,23 @@ Feature: Server
     Then I should receive a response with 200 and "200 OK"
     And I should receive the response in at least 50 ms
 
+  Scenario: Set redirect location
+    When I request to set the code 302 and location "/redirected"
+    Then I should receive a response with 302 and "302 Found"
+    And I should receive a location "/redirected"
+
   Scenario: Reject sleep above maximum
     When I request to set the code 200 and sleep "5m1s"
     Then I should receive a bad request response
     And I should receive the response in less than 1000 ms
+
+  Scenario: Reject redirect location for non-redirect status
+    When I request to set the code 200 and location "/redirected"
+    Then I should receive a bad request response
+
+  Scenario: Reject unsafe redirect location
+    When I request to set the code 302 and location "/redirected%0Abad"
+    Then I should receive a bad request response
 
   Scenario Outline: Set invalid status code
     When I request to set the invalid code "<code>"

--- a/test/lib/status/v1/http.rb
+++ b/test/lib/status/v1/http.rb
@@ -18,6 +18,10 @@ module Status
 
         get(path, opts)
       end
+
+      def code_with_location(code, location, opts = {})
+        get("v1/status/#{code}?location=#{location}", opts.merge(max_redirects: 0))
+      end
     end
   end
 end


### PR DESCRIPTION
## What

- Added optional `location` query support for `/v1/status/{code}` so redirect responses can return a `Location` header.
- Reject invalid redirect targets and `location` on non-redirect responses with `400 Bad Request`.
- Updated README examples plus the Cucumber harness and scenarios for the new API behavior.

## Why

- This lets client tests exercise redirect handling against the local status fixture instead of relying on an external service or custom one-off HTTP server.
- The change keeps existing status-code and `sleep` behavior unchanged while adding a bounded redirect-specific response shape.

## Testing

- `make features` - passed; covers redirect header success, non-redirect rejection, unsafe encoded newline rejection, and existing status, sleep, health, and metrics scenarios.
- `make lint` - passed; Go and Ruby lint passed with the existing gomodguard deprecation warning only.

AI-assisted-by: [Codex](https://openai.com/codex/)
