### PR TITLE
feat(retry): add backoff header fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ all interfaces. For local requests, use:
 curl -i http://localhost:11000/v1/status/200
 curl -i "http://localhost:11000/v1/status/503?sleep=50ms"
 curl -i "http://localhost:11000/v1/status/302?location=/redirected"
+curl -i "http://localhost:11000/v1/status/503?retry_after=2s"
 curl -i http://localhost:11000/status/livez
 ```
 
@@ -68,6 +69,7 @@ Returns the requested HTTP status code.
 GET /v1/status/{code}
 GET /v1/status/{code}?sleep=50ms
 GET /v1/status/{code}?location=/redirected
+GET /v1/status/{code}?retry_after=2s
 ```
 
 > [!NOTE]
@@ -78,6 +80,7 @@ GET /v1/status/{code}?location=/redirected
 | `code` | Path | Yes | Status code to return. Named codes include their standard reason phrase, such as `200 OK`. |
 | `sleep` | Query | No | Delay before returning the response. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), for example `50ms`, `1s`, or `2m`. Must be less than or equal to the effective `max_sleep` and short enough for the configured HTTP request timeout. Parsed durations at or below `0` are accepted and return without waiting. |
 | `location` | Query | No | Redirect target to return in the `Location` header. Only valid for `300` through `399` responses. URL-encode values that contain query delimiters or other reserved characters. |
+| `retry_after` | Query | No | Delay to return in the `Retry-After` header. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), rounded up to whole seconds, and only valid for `300` through `399`, `429`, and `503` responses. Values must be greater than `0`. |
 
 > [!CAUTION]
 > `sleep` intentionally delays the response. Keep durations short in tests so client timeouts and CI jobs do not wait longer than expected. The checked-in local configuration sets `max_sleep` to `2m` and the HTTP timeout to `5s`, so some accepted sleeps can still outlast the transport timeout.
@@ -101,7 +104,8 @@ For codes without a standard reason phrase, the body contains the numeric code:
 ```
 
 Invalid status codes, unparsable `sleep` values, sleeps above the effective
-`max_sleep`, invalid `location` values, and `location` values on non-redirect
+`max_sleep`, invalid `location` values, `location` values on non-redirect
+responses, invalid `retry_after` values, and `retry_after` values on unsupported
 responses return `400 Bad Request`. A `sleep` accepted by `max_sleep` can still
 exceed the configured HTTP request timeout. When the request context is canceled
 while waiting for an accepted sleep, the service returns `408 Request Timeout`.

--- a/internal/api/v1/transport/http/http.go
+++ b/internal/api/v1/transport/http/http.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"math"
 	"net/url"
 	"strconv"
 
@@ -24,6 +25,9 @@ var ErrInvalidSleepDuration = errors.New("status: invalid sleep duration")
 // ErrInvalidLocation is returned when the requested redirect location is unsupported.
 var ErrInvalidLocation = errors.New("status: invalid location")
 
+// ErrInvalidRetryAfter is returned when the requested retry after duration is unsupported.
+var ErrInvalidRetryAfter = errors.New("status: invalid retry after")
+
 // Response marks the status route response type for the shared REST transport.
 type Response any
 
@@ -33,7 +37,8 @@ type Response any
 // parameter is parsed as a duration, rejected when it exceeds the configured
 // maximum, and returns 408 Request Timeout when the request context is canceled
 // while waiting. The optional location query parameter sets a Location response
-// header for 3xx status codes.
+// header for 3xx status codes. The optional retry_after query parameter sets a
+// Retry-After response header for 3xx, 429, and 503 status codes.
 func Register(cfg *config.Config) {
 	rest.Get("/v1/status/{code}", func(ctx context.Context) (*Response, error) {
 		req := meta.Request(ctx)
@@ -44,31 +49,16 @@ func Register(cfg *config.Config) {
 			return nil, status.SafeError(http.StatusBadRequest, err)
 		}
 
-		if s := req.URL.Query().Get("sleep"); !strings.IsEmpty(s) {
-			sleep, err := time.ParseDuration(s)
-			if err != nil {
-				return nil, status.SafeError(http.StatusBadRequest, err)
-			}
-			if sleep > cfg.GetMaxSleep() {
-				return nil, status.SafeError(http.StatusBadRequest, ErrInvalidSleepDuration)
-			}
-
-			timer := time.NewTimer(sleep)
-			defer timer.Stop()
-
-			select {
-			case <-ctx.Done():
-				return nil, status.SafeError(http.StatusRequestTimeout, ctx.Err())
-			case <-timer.C:
-			}
+		if err := waitForSleep(ctx, cfg, req.URL.Query().Get("sleep")); err != nil {
+			return nil, err
 		}
 
-		if location := req.URL.Query().Get("location"); !strings.IsEmpty(location) {
-			if !isRedirectStatusCode(code) || !isValidLocation(location) {
-				return nil, status.SafeError(http.StatusBadRequest, ErrInvalidLocation)
-			}
+		if err := setLocationHeader(res, code, req.URL.Query().Get("location")); err != nil {
+			return nil, err
+		}
 
-			res.Header().Set("Location", location)
+		if err := setRetryAfterHeader(res, code, req.URL.Query().Get("retry_after")); err != nil {
+			return nil, err
 		}
 
 		return nil, status.Errorf(code, "%d %s", code, http.StatusText(code))
@@ -88,8 +78,73 @@ func parseStatusCode(code string) (int, error) {
 	return codeValue, nil
 }
 
+func waitForSleep(ctx context.Context, cfg *config.Config, sleepValue string) error {
+	if strings.IsEmpty(sleepValue) {
+		return nil
+	}
+
+	sleep, err := time.ParseDuration(sleepValue)
+	if err != nil {
+		return status.SafeError(http.StatusBadRequest, err)
+	}
+	if sleep > cfg.GetMaxSleep() {
+		return status.SafeError(http.StatusBadRequest, ErrInvalidSleepDuration)
+	}
+
+	timer := time.NewTimer(sleep)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return status.SafeError(http.StatusRequestTimeout, ctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}
+
+func setLocationHeader(res http.ResponseWriter, code int, location string) error {
+	if strings.IsEmpty(location) {
+		return nil
+	}
+
+	if !isRedirectStatusCode(code) || !isValidLocation(location) {
+		return status.SafeError(http.StatusBadRequest, ErrInvalidLocation)
+	}
+
+	res.Header().Set("Location", location)
+	return nil
+}
+
+func setRetryAfterHeader(res http.ResponseWriter, code int, retryAfterValue string) error {
+	if strings.IsEmpty(retryAfterValue) {
+		return nil
+	}
+
+	if !isRetryAfterStatusCode(code) {
+		return status.SafeError(http.StatusBadRequest, ErrInvalidRetryAfter)
+	}
+
+	retryAfter, err := time.ParseDuration(retryAfterValue)
+	if err != nil {
+		return status.SafeError(http.StatusBadRequest, ErrInvalidRetryAfter)
+	}
+	if retryAfter <= 0 {
+		return status.SafeError(http.StatusBadRequest, ErrInvalidRetryAfter)
+	}
+
+	seconds := int64(math.Ceil(retryAfter.Duration().Seconds()))
+	res.Header().Set("Retry-After", strconv.FormatInt(seconds, 10))
+	return nil
+}
+
 func isRedirectStatusCode(code int) bool {
 	return code >= http.StatusMultipleChoices && code < http.StatusBadRequest
+}
+
+func isRetryAfterStatusCode(code int) bool {
+	return isRedirectStatusCode(code) ||
+		code == http.StatusTooManyRequests ||
+		code == http.StatusServiceUnavailable
 }
 
 func isValidLocation(location string) bool {

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -18,6 +18,10 @@ When('I request to set the code {int} and location {string}') do |code, location
   @response = Status::V1.http.code_with_location(code, location, Status::V1.http.options)
 end
 
+When('I request to set the code {int} and retry after {string}') do |code, retry_after|
+  @response = Status::V1.http.code_with_retry_after(code, retry_after, Status::V1.http.options)
+end
+
 When('I request to set the invalid code {string}') do |code|
   @response = Status::V1.http.code(code, '1ms', Status::V1.http.options)
 end
@@ -38,6 +42,10 @@ end
 
 Then('I should receive a location {string}') do |location|
   expect(@response.headers[:location]).to eq(location)
+end
+
+Then('I should receive a retry after {string}') do |retry_after|
+  expect(@response.headers[:retry_after]).to eq(retry_after)
 end
 
 Then('I should receive the response in at least {int} ms') do |time|

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -27,6 +27,11 @@ Feature: Server
     Then I should receive a response with 302 and "302 Found"
     And I should receive a location "/redirected"
 
+  Scenario: Set retry after
+    When I request to set the code 503 and retry after "500ms"
+    Then I should receive a response with 503 and "503 Service Unavailable"
+    And I should receive a retry after "1"
+
   Scenario: Reject sleep above maximum
     When I request to set the code 200 and sleep "5m1s"
     Then I should receive a bad request response
@@ -38,6 +43,10 @@ Feature: Server
 
   Scenario: Reject unsafe redirect location
     When I request to set the code 302 and location "/redirected%0Abad"
+    Then I should receive a bad request response
+
+  Scenario: Reject retry after for non-retry status
+    When I request to set the code 200 and retry after "2s"
     Then I should receive a bad request response
 
   Scenario Outline: Set invalid status code
@@ -59,3 +68,13 @@ Feature: Server
     Examples:
       | sleep   |
       | invalid |
+
+  Scenario Outline: Set invalid retry after
+    When I request to set the code 503 and retry after "<retry_after>"
+    Then I should receive a bad request response
+
+    Examples:
+      | retry_after |
+      | invalid     |
+      | 0s          |
+      | -1s         |

--- a/test/lib/status/v1/http.rb
+++ b/test/lib/status/v1/http.rb
@@ -22,6 +22,10 @@ module Status
       def code_with_location(code, location, opts = {})
         get("v1/status/#{code}?location=#{location}", opts.merge(max_redirects: 0))
       end
+
+      def code_with_retry_after(code, retry_after, opts = {})
+        get("v1/status/#{code}?retry_after=#{retry_after}", opts)
+      end
     end
   end
 end


### PR DESCRIPTION
## What

- Add optional `retry_after` query support to `/v1/status/{code}` that emits `Retry-After` for 3xx, 429, and 503 responses.
- Document accepted values and invalid combinations, and add Cucumber/Ruby coverage for header setting and rejected inputs.

## Why

- Lets client tests exercise server-directed backoff timing through this fixture service instead of a separate HTTP mock.
- Keeps header shaping constrained to statuses where `Retry-After` has established semantics.

## Testing

- `make features` - passed
- `make lint` - passed
- Feature coverage includes sub-second rounding, unsupported status, unparsable duration, zero duration, and negative duration.

AI-assisted-by: [Codex](https://openai.com/codex/)
