### PR TITLE
docs(readme): clarify report and redirect contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ GET /v1/status/{code}?retry_after=2s
 | --------- | -------- | -------- | ----------- |
 | `code` | Path | Yes | Status code to return. Named codes include their standard reason phrase, such as `200 OK`. |
 | `sleep` | Query | No | Delay before returning the response. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), for example `50ms`, `1s`, or `2m`. Must be less than or equal to the effective `max_sleep` and short enough for the configured HTTP request timeout. Parsed durations at or below `0` are accepted and return without waiting. |
-| `location` | Query | No | Redirect target to return in the `Location` header. Only valid for `300` through `399` responses. URL-encode values that contain query delimiters or other reserved characters. |
+| `location` | Query | No | Redirect target to return in the `Location` header. Only valid for `300` through `399` responses. URL-encode values that contain query delimiters or other reserved characters. Decoded carriage-return and newline characters are rejected. |
 | `retry_after` | Query | No | Delay to return in the `Retry-After` header. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), rounded up to whole seconds, and only valid for `300` through `399`, `429`, and `503` responses. Values must be greater than `0`. |
 
 > [!CAUTION]
@@ -104,9 +104,10 @@ For codes without a standard reason phrase, the body contains the numeric code:
 ```
 
 Invalid status codes, unparsable `sleep` values, sleeps above the effective
-`max_sleep`, invalid `location` values, `location` values on non-redirect
-responses, invalid `retry_after` values, and `retry_after` values on unsupported
-responses return `400 Bad Request`. A `sleep` accepted by `max_sleep` can still
+`max_sleep`, invalid `location` values including decoded carriage-return or
+newline characters, `location` values on non-redirect responses, invalid
+`retry_after` values, and `retry_after` values on unsupported responses return
+`400 Bad Request`. A `sleep` accepted by `max_sleep` can still
 exceed the configured HTTP request timeout. When the request context is canceled
 while waiting for an accepted sleep, the service returns `408 Request Timeout`.
 A shorter client-side timeout can still close the request before a response is

--- a/test/README.md
+++ b/test/README.md
@@ -63,7 +63,8 @@ and generated artifacts before assuming a service regression.
 
 Cucumber and Nonnative write artifacts under `test/reports/`:
 
-- `index.html`: HTML Cucumber report.
+- `features.html`: HTML Cucumber report from `make features`.
+- `benchmarks.html`: HTML Cucumber report from `make benchmarks`.
 - `nonnative.log`: Nonnative process orchestration log.
 - `server.log`: service process log.
 - `*.xml`: JUnit-style Cucumber reports.


### PR DESCRIPTION
## What

- Clarify that redirect `location` values with decoded carriage-return or newline characters are rejected.
- Update the test harness report list to name the HTML files produced by the supported `make features` and `make benchmarks` flows.

## Why

- Readers can now distinguish supported redirect targets from header-injection-style values without tracing handler code or Cucumber scenarios.
- Maintainers looking for generated Cucumber reports are pointed at the files created by the repository make targets.

## Testing

- `make help` - passed
- `make -C test help` - passed
- `go list ./...` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
