### PR TITLE
feat(method): support status requests beyond get

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ all interfaces. For local requests, use:
 
 ```sh
 curl -i http://localhost:11000/v1/status/200
+curl -i -X POST http://localhost:11000/v1/status/503
 curl -i "http://localhost:11000/v1/status/503?sleep=50ms"
 curl -i "http://localhost:11000/v1/status/302?location=/redirected"
 curl -i "http://localhost:11000/v1/status/503?retry_after=2s"
@@ -66,14 +67,15 @@ Returns the requested HTTP status code.
 #### 📥 Request
 
 ```http
-GET /v1/status/{code}
-GET /v1/status/{code}?sleep=50ms
-GET /v1/status/{code}?location=/redirected
-GET /v1/status/{code}?retry_after=2s
+GET|POST|PUT|PATCH|DELETE /v1/status/{code}
+GET|POST|PUT|PATCH|DELETE /v1/status/{code}?sleep=50ms
+GET|POST|PUT|PATCH|DELETE /v1/status/{code}?location=/redirected
+GET|POST|PUT|PATCH|DELETE /v1/status/{code}?retry_after=2s
 ```
 
 > [!NOTE]
 > `code` must parse as an integer from `200` through `999`. Values below `200`, values above `999`, and non-numeric values return `400 Bad Request`.
+> `POST`, `PUT`, `PATCH`, and `DELETE` requests ignore request bodies and use the same query-parameter behavior as `GET`.
 
 | Parameter | Location | Required | Description |
 | --------- | -------- | -------- | ----------- |

--- a/internal/api/v1/transport/http/http.go
+++ b/internal/api/v1/transport/http/http.go
@@ -31,16 +31,23 @@ var ErrInvalidRetryAfter = errors.New("status: invalid retry after")
 // Response marks the status route response type for the shared REST transport.
 type Response any
 
-// Register adds GET /v1/status/{code} to the shared REST router.
+// Register adds /v1/status/{code} routes to the shared REST router.
 //
-// The route accepts status codes from 200 through 999. The optional sleep query
-// parameter is parsed as a duration, rejected when it exceeds the configured
-// maximum, and returns 408 Request Timeout when the request context is canceled
-// while waiting. The optional location query parameter sets a Location response
-// header for 3xx status codes. The optional retry_after query parameter sets a
-// Retry-After response header for 3xx, 429, and 503 status codes.
+// The routes accept status codes from 200 through 999. The optional sleep
+// query parameter is parsed as a duration, rejected when it exceeds the
+// configured maximum, and returns 408 Request Timeout when the request context
+// is canceled while waiting. The optional location query parameter sets a
+// Location response header for 3xx status codes. The optional retry_after query
+// parameter sets a Retry-After response header for 3xx, 429, and 503 status
+// codes.
 func Register(cfg *config.Config) {
-	rest.Get("/v1/status/{code}", func(ctx context.Context) (*Response, error) {
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		rest.Route(strings.Join(strings.Space, method, "/v1/status/{code}"), statusHandler(cfg))
+	}
+}
+
+func statusHandler(cfg *config.Config) func(context.Context) (*Response, error) {
+	return func(ctx context.Context) (*Response, error) {
 		req := meta.Request(ctx)
 		res := meta.Response(ctx)
 
@@ -62,7 +69,7 @@ func Register(cfg *config.Config) {
 		}
 
 		return nil, status.Errorf(code, "%d %s", code, http.StatusText(code))
-	})
+	}
 }
 
 func parseStatusCode(code string) (int, error) {

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -14,6 +14,10 @@ When('I request to set the code {int} and sleep {string}') do |code, sleep|
   @elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
 end
 
+When('I request to set the code {int} with {string}') do |code, method|
+  @response = Status::V1.http.code_with_method(code, method, Status::V1.http.options)
+end
+
 When('I request to set the code {int} and location {string}') do |code, location|
   @response = Status::V1.http.code_with_location(code, location, Status::V1.http.options)
 end

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -17,6 +17,17 @@ Feature: Server
     When I request to set the code 200 without sleep
     Then I should receive a response with 200 and "200 OK"
 
+  Scenario Outline: Set valid status code with method
+    When I request to set the code 503 with "<method>"
+    Then I should receive a response with 503 and "503 Service Unavailable"
+
+    Examples:
+      | method |
+      | POST   |
+      | PUT    |
+      | PATCH  |
+      | DELETE |
+
   Scenario: Set valid sleep
     When I request to set the code 200 and sleep "50ms"
     Then I should receive a response with 200 and "200 OK"

--- a/test/lib/status/v1/http.rb
+++ b/test/lib/status/v1/http.rb
@@ -13,18 +13,43 @@ module Status
       end
 
       def code(code, sleep = '', opts = {})
-        path = "v1/status/#{code}"
-        path = "#{path}?sleep=#{sleep}" unless sleep.to_s.empty?
+        status(code, opts, sleep: sleep)
+      end
 
-        get(path, opts)
+      def code_with_method(code, method, opts = {})
+        status(code, opts, method: method.downcase)
       end
 
       def code_with_location(code, location, opts = {})
-        get("v1/status/#{code}?location=#{location}", opts.merge(max_redirects: 0))
+        status(code, opts.merge(max_redirects: 0), location: location)
       end
 
       def code_with_retry_after(code, retry_after, opts = {})
-        get("v1/status/#{code}?retry_after=#{retry_after}", opts)
+        status(code, opts, retry_after: retry_after)
+      end
+
+      private
+
+      def status(code, opts, method: 'get', **params)
+        path = status_path(code, params)
+        args = payload_method?(method) ? [path, '', opts] : [path, opts]
+
+        send(method, *args)
+      end
+
+      def status_path(code, params)
+        query = params.filter_map { |key, value| "#{key}=#{value}" unless value.to_s.empty? }.join('&')
+        path = "v1/status/#{code}"
+
+        query.empty? ? path : "#{path}?#{query}"
+      end
+
+      def payload_method?(method)
+        %w[post put patch].include?(method)
+      end
+
+      def patch(path, payload, opts = {})
+        with_exception { resource(path, opts).patch(payload) }
       end
     end
   end


### PR DESCRIPTION
## What

- Registered `/v1/status/{code}` for `POST`, `PUT`, `PATCH`, and `DELETE` in addition to the existing `GET` route.
- Kept the existing status-code, `sleep`, `location`, and `retry_after` behavior shared across the supported request forms.
- Updated the README and Cucumber harness so the public examples and integration coverage include non-GET status requests.

## Why

- Developers can use the status fixture for client paths that branch by request type without adding a separate mock handler.
- The change is additive: existing `GET` callers keep the same route, validation, headers, delay handling, and response body behavior.

## Testing

- `make ruby-format` - passed; checked Ruby formatting for the test helper changes.
- `make features` - passed; 29 scenarios and 62 steps, including the new non-GET status scenario outline.
- `make lint` - passed; Go lint reported 0 issues with the existing `gomodguard` deprecation warning, and Ruby inspected 9 files with no offenses.
- Broader CI-only checks such as `make sec`, `make benchmarks`, `make analyse`, and `make coverage` were not run locally.
