### PR TITLE
feat(headers): return caller-provided response metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ curl -i -X POST http://localhost:11000/v1/status/503
 curl -i "http://localhost:11000/v1/status/503?sleep=50ms"
 curl -i "http://localhost:11000/v1/status/302?location=/redirected"
 curl -i "http://localhost:11000/v1/status/503?retry_after=2s"
+curl -i "http://localhost:11000/v1/status/429?header=X-Rate-Limit-Remaining:42"
 curl -i http://localhost:11000/status/livez
 ```
 
@@ -71,6 +72,7 @@ GET|POST|PUT|PATCH|DELETE /v1/status/{code}
 GET|POST|PUT|PATCH|DELETE /v1/status/{code}?sleep=50ms
 GET|POST|PUT|PATCH|DELETE /v1/status/{code}?location=/redirected
 GET|POST|PUT|PATCH|DELETE /v1/status/{code}?retry_after=2s
+GET|POST|PUT|PATCH|DELETE /v1/status/{code}?header=X-Rate-Limit-Remaining:42
 ```
 
 > [!NOTE]
@@ -83,6 +85,7 @@ GET|POST|PUT|PATCH|DELETE /v1/status/{code}?retry_after=2s
 | `sleep` | Query | No | Delay before returning the response. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), for example `50ms`, `1s`, or `2m`. Must be less than or equal to the effective `max_sleep` and short enough for the configured HTTP request timeout. Parsed durations at or below `0` are accepted and return without waiting. |
 | `location` | Query | No | Redirect target to return in the `Location` header. Only valid for `300` through `399` responses. URL-encode values that contain query delimiters or other reserved characters. Decoded carriage-return and newline characters are rejected. |
 | `retry_after` | Query | No | Delay to return in the `Retry-After` header. Parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), rounded up to whole seconds, and only valid for `300` through `399`, `429`, and `503` responses. Values must be greater than `0`. |
+| `header` | Query | No | Extra response header in `Name:Value` form. May be repeated. Header names must use HTTP token characters, decoded values must not contain carriage-return or newline characters, and `Content-Length`, `Content-Type`, `Location`, and `Retry-After` are reserved. URL-encode values that contain query delimiters or other reserved characters. |
 
 > [!CAUTION]
 > `sleep` intentionally delays the response. Keep durations short in tests so client timeouts and CI jobs do not wait longer than expected. The checked-in local configuration sets `max_sleep` to `2m` and the HTTP timeout to `5s`, so some accepted sleeps can still outlast the transport timeout.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.33.0
-	github.com/alexfalkowski/go-service/v2 v2.625.0
+	github.com/alexfalkowski/go-service/v2 v2.626.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.33.0 h1:25fFPDnuIhZjLP1FYvzTayOMpwyjppzaxBXj/TPmkM4=
 github.com/alexfalkowski/go-health/v2 v2.33.0/go.mod h1:H11y8kNp0Ks3ayUNwjPOAV4314lGeH8MuwolYV+6l0M=
-github.com/alexfalkowski/go-service/v2 v2.625.0 h1:gJoUIX/MnQvpXjuwrNG93j1FCNX+vIWOQrjvFdkGoPA=
-github.com/alexfalkowski/go-service/v2 v2.625.0/go.mod h1:NMuzgFLt0LR1fP4uOrOtwF7CQktXE5Yxx+4DfU6xGUY=
+github.com/alexfalkowski/go-service/v2 v2.626.0 h1:2jftn/8V+pcb9cLPz/pccXuwD2zEMxtA64/xGc68GjE=
+github.com/alexfalkowski/go-service/v2 v2.626.0/go.mod h1:NMuzgFLt0LR1fP4uOrOtwF7CQktXE5Yxx+4DfU6xGUY=
 github.com/alexfalkowski/go-sync v1.27.0 h1:Mnk9mhspHt/NzMwFvTyikAla1QF3GDufzuA1v8zvdcY=
 github.com/alexfalkowski/go-sync v1.27.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/internal/api/v1/transport/http/http.go
+++ b/internal/api/v1/transport/http/http.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/net/header"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
@@ -28,6 +29,9 @@ var ErrInvalidLocation = errors.New("status: invalid location")
 // ErrInvalidRetryAfter is returned when the requested retry after duration is unsupported.
 var ErrInvalidRetryAfter = errors.New("status: invalid retry after")
 
+// ErrInvalidHeader is returned when a requested response header is unsupported.
+var ErrInvalidHeader = errors.New("status: invalid header")
+
 // Response marks the status route response type for the shared REST transport.
 type Response any
 
@@ -39,7 +43,8 @@ type Response any
 // is canceled while waiting. The optional location query parameter sets a
 // Location response header for 3xx status codes. The optional retry_after query
 // parameter sets a Retry-After response header for 3xx, 429, and 503 status
-// codes.
+// codes. Repeated header query parameters set additional validated response
+// headers in Name:Value form.
 func Register(cfg *config.Config) {
 	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
 		rest.Route(strings.Join(strings.Space, method, "/v1/status/{code}"), statusHandler(cfg))
@@ -50,21 +55,26 @@ func statusHandler(cfg *config.Config) func(context.Context) (*Response, error) 
 	return func(ctx context.Context) (*Response, error) {
 		req := meta.Request(ctx)
 		res := meta.Response(ctx)
+		query := req.URL.Query()
 
 		code, err := parseStatusCode(req.PathValue("code"))
 		if err != nil {
 			return nil, status.SafeError(http.StatusBadRequest, err)
 		}
 
-		if err := waitForSleep(ctx, cfg, req.URL.Query().Get("sleep")); err != nil {
+		if err := waitForSleep(ctx, cfg, query.Get("sleep")); err != nil {
 			return nil, err
 		}
 
-		if err := setLocationHeader(res, code, req.URL.Query().Get("location")); err != nil {
+		if err := setLocationHeader(res, code, query.Get("location")); err != nil {
 			return nil, err
 		}
 
-		if err := setRetryAfterHeader(res, code, req.URL.Query().Get("retry_after")); err != nil {
+		if err := setRetryAfterHeader(res, code, query.Get("retry_after")); err != nil {
+			return nil, err
+		}
+
+		if err := setExtraHeaders(res, query["header"]); err != nil {
 			return nil, err
 		}
 
@@ -144,6 +154,33 @@ func setRetryAfterHeader(res http.ResponseWriter, code int, retryAfterValue stri
 	return nil
 }
 
+func setExtraHeaders(res http.ResponseWriter, headers []string) error {
+	for _, field := range headers {
+		name, value, ok := strings.CutColon(field)
+		if !ok {
+			return status.SafeError(http.StatusBadRequest, ErrInvalidHeader)
+		}
+		if !isValidExtraHeader(name, value) {
+			return status.SafeError(http.StatusBadRequest, ErrInvalidHeader)
+		}
+
+		res.Header().Set(name, value)
+	}
+
+	return nil
+}
+
+func isValidExtraHeader(name, value string) bool {
+	if !header.ValidFieldName(name) {
+		return false
+	}
+	if isReservedHeaderName(name) {
+		return false
+	}
+
+	return header.ValidFieldValue(value)
+}
+
 func isRedirectStatusCode(code int) bool {
 	return code >= http.StatusMultipleChoices && code < http.StatusBadRequest
 }
@@ -161,4 +198,13 @@ func isValidLocation(location string) bool {
 
 	_, err := url.Parse(location)
 	return err == nil
+}
+
+func isReservedHeaderName(name string) bool {
+	switch strings.ToLower(name) {
+	case "content-length", "content-type", "location", "retry-after":
+		return true
+	default:
+		return false
+	}
 }

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -26,6 +26,18 @@ When('I request to set the code {int} and retry after {string}') do |code, retry
   @response = Status::V1.http.code_with_retry_after(code, retry_after, Status::V1.http.options)
 end
 
+When('I request to set the code {int} and header {string} {string}') do |code, header, value|
+  @response = Status::V1.http.code_with_header(code, header, value, Status::V1.http.options)
+end
+
+When('I request to set the code {int} and headers') do |code, headers|
+  @response = Status::V1.http.code_with_headers(code, headers.rows_hash, Status::V1.http.options)
+end
+
+When('I request to set the code {int} and raw header {string}') do |code, header|
+  @response = Status::V1.http.code_with_raw_header(code, header, Status::V1.http.options)
+end
+
 When('I request to set the invalid code {string}') do |code|
   @response = Status::V1.http.code(code, '1ms', Status::V1.http.options)
 end
@@ -50,6 +62,10 @@ end
 
 Then('I should receive a retry after {string}') do |retry_after|
   expect(@response.headers[:retry_after]).to eq(retry_after)
+end
+
+Then('I should receive a header {string} {string}') do |header, value|
+  expect(@response.headers[header.downcase.tr('-', '_').to_sym]).to eq(value)
 end
 
 Then('I should receive the response in at least {int} ms') do |time|

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -43,6 +43,14 @@ Feature: Server
     Then I should receive a response with 503 and "503 Service Unavailable"
     And I should receive a retry after "1"
 
+  Scenario: Set extra response headers
+    When I request to set the code 429 and headers
+      | X-Rate-Limit-Remaining | 42  |
+      | X-Rate-Limit-Limit     | 100 |
+    Then I should receive a response with 429 and "429 Too Many Requests"
+    And I should receive a header "X-Rate-Limit-Remaining" "42"
+    And I should receive a header "X-Rate-Limit-Limit" "100"
+
   Scenario: Reject sleep above maximum
     When I request to set the code 200 and sleep "5m1s"
     Then I should receive a bad request response
@@ -59,6 +67,20 @@ Feature: Server
   Scenario: Reject retry after for non-retry status
     When I request to set the code 200 and retry after "2s"
     Then I should receive a bad request response
+
+  Scenario: Reject malformed extra response header
+    When I request to set the code 200 and raw header "X-Trace-Id"
+    Then I should receive a bad request response
+
+  Scenario Outline: Reject invalid extra response header
+    When I request to set the code 200 and header "<header>" "<value>"
+    Then I should receive a bad request response
+
+    Examples:
+      | header       | value      |
+      | Bad Header   | value      |
+      | X-Trace-Id   | abc%0Abad  |
+      | Content-Type | text/plain |
 
   Scenario Outline: Set invalid status code
     When I request to set the invalid code "<code>"

--- a/test/lib/status/v1/http.rb
+++ b/test/lib/status/v1/http.rb
@@ -28,6 +28,18 @@ module Status
         status(code, opts, retry_after: retry_after)
       end
 
+      def code_with_header(code, header, value, opts = {})
+        status(code, opts, header: "#{header}:#{value}")
+      end
+
+      def code_with_headers(code, headers, opts = {})
+        status(code, opts, header: headers.map { |header, value| "#{header}:#{value}" })
+      end
+
+      def code_with_raw_header(code, header, opts = {})
+        status(code, opts, header: header)
+      end
+
       private
 
       def status(code, opts, method: 'get', **params)
@@ -38,10 +50,14 @@ module Status
       end
 
       def status_path(code, params)
-        query = params.filter_map { |key, value| "#{key}=#{value}" unless value.to_s.empty? }.join('&')
+        query = params.flat_map { |key, value| query_values(key, value) }.join('&')
         path = "v1/status/#{code}"
 
         query.empty? ? path : "#{path}?#{query}"
+      end
+
+      def query_values(key, value)
+        Array(value).filter_map { |item| "#{key}=#{item}" unless item.to_s.empty? }
       end
 
       def payload_method?(method)


### PR DESCRIPTION
## What

- Added repeated `header` query parameters on `/v1/status/{code}` for setting validated extra response metadata.
- Reject invalid field names, invalid field values, and reserved endpoint/framework-owned fields such as `Content-Type`, `Content-Length`, `Location`, and `Retry-After`.
- Updated README examples and the status-route parameter table for the new query form.
- Added Cucumber coverage for multiple accepted response fields and invalid extra response field requests.
- Updated `go-service` to `v2.626.0` and use its `net/header` validation helpers instead of importing lower-level HTTP internals directly.

## Why

- Developers can model status-plus-response-metadata upstream behavior with the existing deterministic status endpoint instead of standing up a separate mock service.
- Keeping validation on the shared go-service header surface avoids duplicating HTTP field-name and field-value rules in this service.
- The feature intentionally stays HTTP-only for now; gRPC metadata support is out of scope.

## Testing

- `gmake package=internal/api/v1/transport/http specs` - passed; compiled the changed Go package through the repository test target.
- `gmake features` - passed; 33 scenarios and 72 steps, including multiple accepted extra response fields plus invalid name, invalid value, and reserved-field rejection.
- `gmake lint` - passed; Go lint reported the existing gomodguard deprecation warning and 0 issues, Ruby lint inspected 9 files with no offenses.
- `git diff --check` - passed.
- Broader CI checks such as `gmake sec`, `gmake benchmarks`, `gmake analyse`, `gmake coverage`, and docker image checks were not run locally.
