### PR TITLE
build(deps): add claude code skills wiring

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../bin/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+<!-- BEGIN bin claude-init -->
+@AGENTS.md
+@bin/AGENTS.md
+<!-- END bin claude-init -->

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 include bin/build/make/help.mak
 include bin/build/make/http.mak
 include bin/build/make/git.mak
+include bin/build/make/claude.mak


### PR DESCRIPTION
## What

- Bump the `bin` submodule to include the shared Claude Code wiring.
- Add `include bin/build/make/claude.mak` and run `make claude-init`, creating a
  `.claude/skills` symlink to the shared `bin/skills` directory and a `CLAUDE.md`
  that imports the shared `AGENTS.md` (and this repository's own `AGENTS.md` when
  present).
- Lets Claude Code discover the shared skills (invoked as `/skill-name`)
  alongside the existing Codex setup. No build or runtime behavior changes.

## Why

- Claude Code does not scan submodules, so `bin/skills` was invisible to it.
  This wires the repository once so every clone works with no per-machine setup
  beyond the one-time workspace trust prompt.

## Testing

- `make help` - passed (Makefile still parses with the new include)
- `make claude-init` - passed and idempotent; `.claude/skills` resolves the 23
  shared skills
- Scoped to wiring; no code changes in this repository to test.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
