### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.742.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.37.0
-	github.com/alexfalkowski/go-service/v2 v2.741.0
+	github.com/alexfalkowski/go-service/v2 v2.742.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.37.0 h1:UItNzlTyEafq5MoqaHpMxYqXAHzqL6Cpjb9wujPedL0=
 github.com/alexfalkowski/go-health/v2 v2.37.0/go.mod h1:t6fhN4YxTB26TSnKUjLyjZFRbKv4EkBwinWd/fFn4Us=
-github.com/alexfalkowski/go-service/v2 v2.741.0 h1:1T7P65u01ZEETZA+uME+tBkQkgucwNANKi3jLPGoPjk=
-github.com/alexfalkowski/go-service/v2 v2.741.0/go.mod h1:EIw0JuQBvpxZtlRJkitTFJm8TCQNNqlCrF9VNldBXUw=
+github.com/alexfalkowski/go-service/v2 v2.742.0 h1:pRzNfoS2+b20hahdS+iQtYrMcGlgZ82nFH0uf63VOso=
+github.com/alexfalkowski/go-service/v2 v2.742.0/go.mod h1:EIw0JuQBvpxZtlRJkitTFJm8TCQNNqlCrF9VNldBXUw=
 github.com/alexfalkowski/go-sync v1.33.0 h1:XN5XUFJ/w/emDUJ0CXZOZl6UVTkx/zj0y6kaFWIHbk8=
 github.com/alexfalkowski/go-sync v1.33.0/go.mod h1:IzEbtMNtoLHdIfoO6Z+f7azto4wjLuj6ZgAOrpKLZbY=
 github.com/arl/statsviz v0.8.1 h1:9Ns7GBWCPWn46M/KfqZ5BqRxU578e/MV7/DOwpt2Sd8=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.742.0
